### PR TITLE
webstorm .idea and .env add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+.idea
+.env


### PR DESCRIPTION

- .idea is a folder that is generated by the Webstorm editor
- .env file was missing from .gitignore. 